### PR TITLE
Check for tag "basic" prior to filtering. Exit if there is no tag "basic".

### DIFF
--- a/FilterGtf/FilterGtf.py
+++ b/FilterGtf/FilterGtf.py
@@ -57,8 +57,8 @@ def filter_gff(gtf_file, outputdir):
         print('Saving filtered gtf file.')
         annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
     else:
-        print('No tag \"basic\". Returning input annotation as output. Exiting.')
-        annotation.to_csv(f"{outputdir}/unfiltered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+        print('No tag \"basic\". Exiting.')
+        exit()
 
 def main():
     (gtf_file, outputdir) = cli()

--- a/FilterGtf/FilterGtf.py
+++ b/FilterGtf/FilterGtf.py
@@ -3,7 +3,8 @@ import csv
 import argparse
 
 def cli():
-    parser = argparse.ArgumentParser(description='Filter genomic annotation from GENCODE or ENSEMBL in GTF format.')
+    parser = argparse.ArgumentParser(description='Filter genomic annotation from GENCODE or ENSEMBL in GTF format by tag \"basic\" and transcript_support_level.'\
+    ' These flags are currently (20220223) annotated for Homo sapiens and Mus musculus organisms.')
     required = parser.add_argument_group('required arguments')
     required.add_argument('-a', '--annotation', type=str, required=True,
                         help='Annotation file from GENCODE or ENSEMBL in GTF format.')
@@ -34,20 +35,30 @@ def filter_gff(gtf_file, outputdir):
                                     })
     # Filter transcripts by basic tag
     print("Number of entries in input annotation:", len(annotation))
-    annotation = annotation.loc[annotation['annotations'].str.contains('tag "basic"') | (annotation['feature'] == 'gene'), :]
-    print("Number of entries after filtering for tag \"basic\":", len(annotation))
-    # Filter annotation gene-by-gene by transcript level support (TSL), to keep higher confidence transcripts where possible (TSL1 and 2)
-    df_TSL = annotation.loc[annotation['annotations'].str.contains('transcript_support_level "1|transcript_support_level "2', regex=True), :]
-    gene_ids = df_TSL["annotations"].str.split(";", n=1, expand=True)[0].unique().tolist()
-    print("Number of genes that contain TSL1 or TSL2 transcripts:", len(gene_ids))
-    # Keeping only TSL1 and TSL2 entries for genes that contain them, discardig other entries (no TSL information or TSL3-5)
-    print('Filtering out low-confidence transcripts.')
-    df_t = annotation.loc[(annotation['feature'] != 'gene') & (annotation['annotations'].str.contains('|'.join(gene_ids))) , :]
-    df_t = df_t.loc[~df_t['annotations'].str.contains('transcript_support_level "1"|transcript_support_level "2"', regex=True)]
-    annotation.drop(index=df_t.index, inplace=True)
-    print("Number of entries in filtered annotation.", len(annotation))
-    print('Saving filtered gtf file.')
-    annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+    # Check if annotation contains tag "basic"
+    print("Checking for basic flag...")
+    basic = annotation['annotations'].str.contains('basic', regex=True)
+    if basic.any():
+        print("Basic flag available.")
+        nbasic = basic.value_counts()[True]
+        print(f"{nbasic} entries flagged as basic.")
+        annotation = annotation.loc[annotation['annotations'].str.contains('tag "basic"') | (annotation['feature'] == 'gene'), :]
+        print("Number of entries after filtering for tag \"basic\":", len(annotation))
+        # Filter annotation gene-by-gene by transcript level support (TSL), to keep higher confidence transcripts where possible (TSL1 and 2)
+        df_TSL = annotation.loc[annotation['annotations'].str.contains('transcript_support_level "1|transcript_support_level "2', regex=True), :]
+        gene_ids = df_TSL["annotations"].str.split(";", n=1, expand=True)[0].unique().tolist()
+        print("Number of genes that contain TSL1 or TSL2 transcripts:", len(gene_ids))
+        # Keeping only TSL1 and TSL2 entries for genes that contain them, discardig other entries (no TSL information or TSL3-5)
+        print('Filtering out low-confidence transcripts.')
+        df_t = annotation.loc[(annotation['feature'] != 'gene') & (annotation['annotations'].str.contains('|'.join(gene_ids))) , :]
+        df_t = df_t.loc[~df_t['annotations'].str.contains('transcript_support_level "1"|transcript_support_level "2"', regex=True)]
+        annotation.drop(index=df_t.index, inplace=True)
+        print("Number of entries in filtered annotation.", len(annotation))
+        print('Saving filtered gtf file.')
+        annotation.to_csv(f"{outputdir}/filtered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
+    else:
+        print('No tag \"basic\". Returning input annotation as output. Exiting.')
+        annotation.to_csv(f"{outputdir}/unfiltered.{gtf_file.split('/')[-1]}", header=None, index=None, sep='\t', quoting=csv.QUOTE_NONE)
 
 def main():
     (gtf_file, outputdir) = cli()


### PR DESCRIPTION
FiterGtf filters entries by basic tag and by transcript_support_level. As these tags are currently only annotated for Gencode and Ensembl Human and Mouse genomes, I added a check for tag "basic". 
The check causes the script to exit if there is no tag "basic" in the annotation.